### PR TITLE
Added missing prefix to installation script

### DIFF
--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -399,7 +399,7 @@ class UpgradeSchema implements UpgradeSchemaInterface
                 ->addForeignKey(
                     'FK_ITEM_GROUP_PRICE_LIST_ID',
                     'price_list_id',
-                    'dealer4dealer_price_list',
+                    $setup->getTable('dealer4dealer_price_list'),
                     'id',
                     Table::ACTION_CASCADE
                 );


### PR DESCRIPTION
Ran into the issue where the installation script did not take prefixes into account. This gave the following error during `bin/magento setup:upgrade`

> Warning: Undefined array key "dealer4dealer_price_list" in /data/a4htech/magento2/vendor/magento/framework/Setup/Declaration/Schema/Db/SchemaBuilder.php on line 153

 By using `$setup->getTable` this issue is now resolved.